### PR TITLE
Account management screen

### DIFF
--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import kotlin.reflect.KFunction2
+import app.gamenative.ui.screen.accounts.AccountManagementScreen
 
 @Composable
 fun PluviaMain(
@@ -588,12 +589,17 @@ fun PluviaMain(
 
         NavHost(
             navController = navController,
-            startDestination = PluviaScreen.LoginUser.route,
+            startDestination = PluviaScreen.Home.route,
         ) {
             /** Login **/
             /** Login **/
             composable(route = PluviaScreen.LoginUser.route) {
                 UserLoginScreen()
+            }
+            
+            /** Account Management **/
+            composable(route = PluviaScreen.AccountManagement.route) {
+                AccountManagementScreen(navController = navController)
             }
             /** Library, Downloads, Friends **/
             /** Library, Downloads, Friends **/

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -179,12 +179,7 @@ fun PluviaMain(
                 }
 
                 MainViewModel.MainUiEvent.OnLoggedOut -> {
-                    // Pop stack and go back to login.
-                    navController.popBackStack(
-                        route = PluviaScreen.LoginUser.route,
-                        inclusive = false,
-                        saveState = false,
-                    )
+                    // Do nothing - let users stay on current page after logout
                 }
 
                 is MainViewModel.MainUiEvent.OnLogonEnded -> {

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -629,9 +629,6 @@ fun PluviaMain(
                     onNavigateRoute = {
                         navController.navigate(it)
                     },
-                    onLogout = {
-                        SteamService.logOut()
-                    },
                 )
             }
 

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -594,7 +594,14 @@ fun PluviaMain(
 
             /** Account Management **/
             composable(route = PluviaScreen.AccountManagement.route) {
-                AccountManagementScreen(navController = navController)
+                AccountManagementScreen(
+                    onNavigateRoute = {
+                        navController.navigate(it)
+                    },
+                    onBack = {
+                        navController.navigateUp()
+                    },
+                )
             }
             /** Library, Downloads, Friends **/
             /** Library, Downloads, Friends **/

--- a/app/src/main/java/app/gamenative/ui/PluviaMain.kt
+++ b/app/src/main/java/app/gamenative/ui/PluviaMain.kt
@@ -34,6 +34,7 @@ import app.gamenative.Constants
 import app.gamenative.MainActivity
 import app.gamenative.PluviaApp
 import app.gamenative.PrefManager
+import app.gamenative.R
 import app.gamenative.enums.AppTheme
 import app.gamenative.enums.LoginResult
 import app.gamenative.enums.PathType
@@ -51,6 +52,7 @@ import app.gamenative.ui.enums.Orientation
 import app.gamenative.ui.model.MainViewModel
 import app.gamenative.ui.screen.HomeScreen
 import app.gamenative.ui.screen.PluviaScreen
+import app.gamenative.ui.screen.accounts.AccountManagementScreen
 import app.gamenative.ui.screen.chat.ChatScreen
 import app.gamenative.ui.screen.login.UserLoginScreen
 import app.gamenative.ui.screen.settings.SettingsScreen
@@ -58,20 +60,18 @@ import app.gamenative.ui.screen.xserver.XServerScreen
 import app.gamenative.ui.theme.PluviaTheme
 import app.gamenative.utils.ContainerUtils
 import app.gamenative.utils.IntentLaunchManager
-import app.gamenative.R
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.winlator.container.ContainerManager
 import com.winlator.xenvironment.ImageFsInstaller
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects.ECloudPendingRemoteOperation
 import java.util.Date
 import java.util.EnumSet
+import kotlin.reflect.KFunction2
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import kotlin.reflect.KFunction2
-import app.gamenative.ui.screen.accounts.AccountManagementScreen
 
 @Composable
 fun PluviaMain(
@@ -591,7 +591,7 @@ fun PluviaMain(
             composable(route = PluviaScreen.LoginUser.route) {
                 UserLoginScreen()
             }
-            
+
             /** Account Management **/
             composable(route = PluviaScreen.AccountManagement.route) {
                 AccountManagementScreen(navController = navController)

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Settings
@@ -106,13 +105,13 @@ fun ProfileDialog(
 
                 /* Action Buttons */
                 Spacer(modifier = Modifier.height(16.dp))
-                
+
                 FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.AccountManagement.route) }) {
                     Icon(imageVector = Icons.Default.AccountCircle, contentDescription = null)
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
                     Text(text = "Manage Accounts")
                 }
-                
+
                 FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.Settings.route) }) {
                     Icon(imageVector = Icons.Default.Settings, contentDescription = null)
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -49,7 +49,6 @@ fun ProfileDialog(
     state: EPersonaState,
     onStatusChange: (EPersonaState) -> Unit,
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (!openDialog) {
@@ -125,12 +124,6 @@ fun ProfileDialog(
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
                     Text(text = "Help & Support")
                 }
-
-                FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = onLogout) {
-                    Icon(imageVector = Icons.AutoMirrored.Filled.Logout, contentDescription = null)
-                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
-                    Text(text = "Log Out")
-                }
             }
         },
         confirmButton = {
@@ -152,7 +145,6 @@ private fun Preview_ProfileDialog() {
             state = EPersonaState.Online,
             onStatusChange = {},
             onNavigateRoute = {},
-            onLogout = {},
             onDismiss = {},
         )
     }

--- a/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
+++ b/app/src/main/java/app/gamenative/ui/component/dialog/ProfileDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
@@ -106,6 +107,13 @@ fun ProfileDialog(
 
                 /* Action Buttons */
                 Spacer(modifier = Modifier.height(16.dp))
+                
+                FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.AccountManagement.route) }) {
+                    Icon(imageVector = Icons.Default.AccountCircle, contentDescription = null)
+                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))
+                    Text(text = "Manage Accounts")
+                }
+                
                 FilledTonalButton(modifier = Modifier.fillMaxWidth(), onClick = { onNavigateRoute(PluviaScreen.Settings.route) }) {
                     Icon(imageVector = Icons.Default.Settings, contentDescription = null)
                     Spacer(modifier = Modifier.size(ButtonDefaults.IconSize))

--- a/app/src/main/java/app/gamenative/ui/component/topbar/AccountButton.kt
+++ b/app/src/main/java/app/gamenative/ui/component/topbar/AccountButton.kt
@@ -29,7 +29,6 @@ import timber.log.Timber
 @Composable
 fun AccountButton(
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     var persona by remember { mutableStateOf<SteamFriend?>(null) }
@@ -68,10 +67,6 @@ fun AccountButton(
             onNavigateRoute(it)
             showDialog = false
         },
-        onLogout = {
-            onLogout()
-            showDialog = false
-        },
         onDismiss = {
             showDialog = false
         },
@@ -98,7 +93,6 @@ private fun Preview_AccountButton() {
             actions = {
                 AccountButton(
                     onNavigateRoute = {},
-                    onLogout = {},
                 )
             },
         )

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -117,7 +117,10 @@ class LibraryViewModel @Inject constructor(
                 .asSequence()
                 .filter { item ->
                     SteamService.familyMembers.ifEmpty {
-                        listOf(SteamService.userSteamId!!.accountID.toInt())
+                        // Handle the case where userSteamId might be null
+                        SteamService.userSteamId?.let { steamId ->
+                            listOf(steamId.accountID.toInt())
+                        } ?: emptyList()
                     }.map {
                         item.ownerAccountId.contains(it)
                     }.any()
@@ -129,7 +132,7 @@ class LibraryViewModel @Inject constructor(
                     if (currentState.appInfoSortType.contains(AppFilter.SHARED)) {
                         true
                     } else {
-                        item.ownerAccountId.contains(SteamService.userSteamId!!.accountID.toInt())
+                        item.ownerAccountId.contains(SteamService.userSteamId?.accountID?.toInt() ?: 0)
                     }
                 }
                 .filter { item ->

--- a/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/app/gamenative/ui/model/LibraryViewModel.kt
@@ -17,6 +17,8 @@ import app.gamenative.ui.enums.AppFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.EnumSet
 import javax.inject.Inject
+import kotlin.math.max
+import kotlin.math.min
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,8 +26,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import kotlin.math.max
-import kotlin.math.min
 
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
@@ -39,8 +39,8 @@ class LibraryViewModel @Inject constructor(
     var listState: LazyListState by mutableStateOf(LazyListState(0, 0))
 
     // How many items loaded on one page of results
-    private var paginationCurrentPage: Int = 0;
-    private var lastPageInCurrentFilter: Int = 0;
+    private var paginationCurrentPage: Int = 0
+    private var lastPageInCurrentFilter: Int = 0
 
     // Complete and unfiltered app list
     private var appList: List<SteamApp> = emptyList()
@@ -151,8 +151,8 @@ class LibraryViewModel @Inject constructor(
                 }
                 .sortedWith(
                     // Comes from DAO in alphabetical order
-                    compareByDescending<SteamApp> { downloadDirectoryApps.contains(SteamService.getAppDirName(it)) }
-                );
+                    compareByDescending<SteamApp> { downloadDirectoryApps.contains(SteamService.getAppDirName(it)) },
+                )
 
             // Total count for the current filter
             val totalFound = filteredList.count()
@@ -179,14 +179,14 @@ class LibraryViewModel @Inject constructor(
                 }
                 .toList()
 
-            Timber.tag("LibraryViewModel").d("Filtered list size: ${totalFound}")
+            Timber.tag("LibraryViewModel").d("Filtered list size: $totalFound")
             _state.update {
                 it.copy(
                     appInfoList = filteredListPage,
                     currentPaginationPage = paginationPage + 1, // visual display is not 0 indexed
                     lastPaginationPage = lastPageInCurrentFilter + 1,
                     totalAppsInFilter = totalFound,
-                    )
+                )
             }
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
@@ -21,7 +21,6 @@ fun HomeScreen(
     onChat: (Long) -> Unit,
     onClickExit: () -> Unit,
     onClickPlay: (Int, Boolean) -> Unit,
-    onLogout: () -> Unit,
     onNavigateRoute: (String) -> Unit,
 ) {
     val homeState by viewModel.homeState.collectAsStateWithLifecycle()
@@ -35,7 +34,6 @@ fun HomeScreen(
     HomeLibraryScreen(
         onClickPlay = onClickPlay,
         onNavigateRoute = onNavigateRoute,
-        onLogout = onLogout,
     )
 }
 
@@ -53,7 +51,6 @@ private fun Preview_HomeScreenContent() {
         HomeScreen(
             onChat = {},
             onClickPlay = { _, _ -> },
-            onLogout = {},
             onNavigateRoute = {},
             onClickExit = {}
         )

--- a/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/HomeScreen.kt
@@ -52,7 +52,7 @@ private fun Preview_HomeScreenContent() {
             onChat = {},
             onClickPlay = { _, _ -> },
             onNavigateRoute = {},
-            onClickExit = {}
+            onClickExit = {},
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/PluviaScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/PluviaScreen.kt
@@ -8,6 +8,7 @@ sealed class PluviaScreen(val route: String) {
     data object Home : PluviaScreen("home")
     data object XServer : PluviaScreen("xserver")
     data object Settings : PluviaScreen("settings")
+    data object AccountManagement : PluviaScreen("accounts")
     data object Chat : PluviaScreen("chat/{id}") {
         fun route(id: Long) = "chat/$id"
         const val ARG_ID = "id"

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -4,18 +4,18 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import app.gamenative.ui.component.topbar.BackButton
 import com.alorma.compose.settings.ui.SettingsGroup
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.graphics.Brush
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
 
@@ -23,7 +23,7 @@ import com.skydoves.landscapist.coil.CoilImage
 @Composable
 fun AccountManagementScreen(
     navController: NavController,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
     val scrollState = rememberScrollState()
@@ -53,7 +53,7 @@ fun AccountManagementScreen(
 
 @Composable
 private fun AccountsGroup(
-    navController: NavController
+    navController: NavController,
 ) {
     SettingsGroup(title = { Text(text = "Accounts") }) {
         SteamAccountSection(navController = navController)
@@ -68,33 +68,33 @@ private fun AccountInfoCard() {
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        )
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Icon(
                     imageVector = Icons.Default.Info,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
                 )
                 Text(
                     text = "Platform Information",
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            
+
             Text(
                 text = "• You can use GameNative without logging into any accounts\n" +
-                      "• Steam login enables downloading and playing Steam games",
+                    "• Steam login enables downloading and playing Steam games",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -112,20 +112,20 @@ fun AccountSection(
     onLogout: () -> Unit,
     modifier: Modifier = Modifier,
     isLoading: Boolean = false,
-    error: String? = null
+    error: String? = null,
 ) {
     val primaryColor = MaterialTheme.colorScheme.primary
     val tertiaryColor = MaterialTheme.colorScheme.tertiary
-    
+
     Card(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.95f)
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.95f),
         ),
         border = BorderStroke(1.dp, primaryColor.copy(alpha = 0.2f)),
-        shape = RoundedCornerShape(16.dp)
+        shape = RoundedCornerShape(16.dp),
     ) {
         Box(
             modifier = Modifier
@@ -133,23 +133,23 @@ fun AccountSection(
                 .height(2.dp)
                 .background(
                     brush = Brush.horizontalGradient(
-                        colors = listOf(primaryColor, tertiaryColor, primaryColor)
-                    )
-                )
+                        colors = listOf(primaryColor, tertiaryColor, primaryColor),
+                    ),
+                ),
         )
-        
+
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 CoilImage(
                     imageModel = { icon },
                     imageOptions = ImageOptions(
                         contentScale = androidx.compose.ui.layout.ContentScale.Fit,
-                        alignment = androidx.compose.ui.Alignment.Center
+                        alignment = androidx.compose.ui.Alignment.Center,
                     ),
                     modifier = Modifier.size(32.dp),
                     failure = {
@@ -157,77 +157,82 @@ fun AccountSection(
                             imageVector = Icons.Default.AccountCircle,
                             contentDescription = null,
                             modifier = Modifier.size(32.dp),
-                            tint = if (isLoggedIn) 
-                                MaterialTheme.colorScheme.onPrimaryContainer 
-                            else 
+                            tint = if (isLoggedIn) {
+                                MaterialTheme.colorScheme.onPrimaryContainer
+                            } else {
                                 MaterialTheme.colorScheme.onSurface
+                            },
                         )
-                    }
+                    },
                 )
-                
+
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = title,
                         style = MaterialTheme.typography.titleMedium,
-                        color = if (isLoggedIn) 
-                            MaterialTheme.colorScheme.onPrimaryContainer 
-                        else 
+                        color = if (isLoggedIn) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
                             MaterialTheme.colorScheme.onSurface
+                        },
                     )
-                    
+
                     Text(
-                        text = if (isLoggedIn && username != null) 
-                            "Logged in as $username" 
-                        else 
-                            description,
+                        text = if (isLoggedIn && username != null) {
+                            "Logged in as $username"
+                        } else {
+                            description
+                        },
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (isLoggedIn) 
+                        color = if (isLoggedIn) {
                             MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
-                        else 
+                        } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
+                        },
                     )
                 }
-                
+
                 // Status indicator
                 Icon(
                     imageVector = if (isLoggedIn) Icons.Default.CheckCircle else Icons.Default.Circle,
                     contentDescription = if (isLoggedIn) "Connected" else "Not connected",
-                    tint = if (isLoggedIn) 
-                        MaterialTheme.colorScheme.primary 
-                    else 
-                        MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp)
+                    tint = if (isLoggedIn) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier.size(20.dp),
                 )
             }
-            
+
             // Error message
             if (error != null) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer
-                    )
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
                 ) {
                     Text(
                         text = error,
                         modifier = Modifier.padding(12.dp),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer
+                        color = MaterialTheme.colorScheme.onErrorContainer,
                     )
                 }
             }
-            
+
             // Action button
             if (isLoggedIn) {
                 OutlinedButton(
                     onClick = onLogout,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isLoading
+                    enabled = !isLoading,
                 ) {
                     if (isLoading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp
+                            strokeWidth = 2.dp,
                         )
                     } else {
                         Icon(Icons.Default.Logout, contentDescription = null)
@@ -239,13 +244,13 @@ fun AccountSection(
                 Button(
                     onClick = onLogin,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isLoading
+                    enabled = !isLoading,
                 ) {
                     if (isLoading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary
+                            color = MaterialTheme.colorScheme.onPrimary,
                         )
                     } else {
                         Icon(Icons.Default.Login, contentDescription = null)

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import app.gamenative.ui.component.topbar.BackButton
 import com.alorma.compose.settings.ui.SettingsGroup
 import com.skydoves.landscapist.ImageOptions
@@ -58,45 +60,6 @@ private fun AccountsGroup(
     SettingsGroup(title = { Text(text = "Accounts") }) {
         SteamAccountSection(navController = navController)
         // Other account sections (GOG, Epic Games, etc.)
-    }
-}
-
-@Composable
-private fun AccountInfoCard() {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        ),
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Info,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = "Platform Information",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            Text(
-                text = "• You can use GameNative without logging into any accounts\n" +
-                    "• Steam login enables downloading and playing Steam games",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
     }
 }
 
@@ -261,4 +224,11 @@ fun AccountSection(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AccountManagementScreenPreview() {
+    val navController = rememberNavController()
+    AccountManagementScreen(navController = navController)
 }

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -16,6 +16,8 @@ import app.gamenative.ui.component.topbar.BackButton
 import com.alorma.compose.settings.ui.SettingsGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Brush
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.coil.CoilImage
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,7 +105,7 @@ private fun AccountInfoCard() {
 fun AccountSection(
     title: String,
     description: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: String,
     isLoggedIn: Boolean,
     username: String?,
     onLogin: () -> Unit,
@@ -143,14 +145,24 @@ fun AccountSection(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
+                CoilImage(
+                    imageModel = { icon },
+                    imageOptions = ImageOptions(
+                        contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+                        alignment = androidx.compose.ui.Alignment.Center
+                    ),
                     modifier = Modifier.size(32.dp),
-                    tint = if (isLoggedIn) 
-                        MaterialTheme.colorScheme.onPrimaryContainer 
-                    else 
-                        MaterialTheme.colorScheme.onSurface
+                    failure = {
+                        Icon(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(32.dp),
+                            tint = if (isLoggedIn) 
+                                MaterialTheme.colorScheme.onPrimaryContainer 
+                            else 
+                                MaterialTheme.colorScheme.onSurface
+                        )
+                    }
                 )
                 
                 Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import app.gamenative.ui.component.topbar.BackButton
 import app.gamenative.ui.theme.PluviaTheme
 import com.alorma.compose.settings.ui.SettingsGroup
@@ -28,7 +26,8 @@ import com.skydoves.landscapist.coil.CoilImage
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountManagementScreen(
-    navController: NavController,
+    onNavigateRoute: (String) -> Unit,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
@@ -40,7 +39,7 @@ fun AccountManagementScreen(
             CenterAlignedTopAppBar(
                 title = { Text(text = "Manage Accounts") },
                 navigationIcon = {
-                    BackButton(onClick = { navController.popBackStack() })
+                    BackButton(onClick = { onBack() })
                 },
             )
         },
@@ -52,17 +51,17 @@ fun AccountManagementScreen(
                 .fillMaxSize()
                 .verticalScroll(scrollState),
         ) {
-            AccountsGroup(navController = navController)
+            AccountsGroup(onNavigateRoute = onNavigateRoute)
         }
     }
 }
 
 @Composable
 private fun AccountsGroup(
-    navController: NavController,
+    onNavigateRoute: (String) -> Unit,
 ) {
     SettingsGroup(title = { Text(text = "Accounts") }) {
-        SteamAccountSection(navController = navController)
+        SteamAccountSection(onNavigateRoute = onNavigateRoute)
         // Other account sections (GOG, Epic Games, etc.)
     }
 }
@@ -235,7 +234,9 @@ fun AccountSection(
 @Composable
 private fun AccountManagementScreenPreview() {
     PluviaTheme {
-        val navController = rememberNavController()
-        AccountManagementScreen(navController = navController)
+        AccountManagementScreen(
+            onNavigateRoute = {},
+            onBack = {},
+        )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -1,5 +1,6 @@
 package app.gamenative.ui.screen.accounts
 
+import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -17,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import app.gamenative.ui.component.topbar.BackButton
+import app.gamenative.ui.theme.PluviaTheme
 import com.alorma.compose.settings.ui.SettingsGroup
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImage
@@ -226,9 +228,12 @@ fun AccountSection(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Preview(device = "spec:width=1920px,height=1080px,dpi=440") // Odin2 Mini
 @Composable
 private fun AccountManagementScreenPreview() {
-    val navController = rememberNavController()
-    AccountManagementScreen(navController = navController)
+    PluviaTheme {
+        val navController = rememberNavController()
+        AccountManagementScreen(navController = navController)
+    }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -200,7 +202,7 @@ fun AccountSection(
                             strokeWidth = 2.dp,
                         )
                     } else {
-                        Icon(Icons.Default.Logout, contentDescription = null)
+                        Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = null)
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("Sign Out")
@@ -218,7 +220,7 @@ fun AccountSection(
                             color = MaterialTheme.colorScheme.onPrimary,
                         )
                     } else {
-                        Icon(Icons.Default.Login, contentDescription = null)
+                        Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(if (isLoading) "Signing In..." else "Sign In")

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/AccountManagementScreen.kt
@@ -1,0 +1,247 @@
+package app.gamenative.ui.screen.accounts
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import app.gamenative.ui.component.topbar.BackButton
+import com.alorma.compose.settings.ui.SettingsGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Brush
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountManagementScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    val snackBarHostState = remember { SnackbarHostState() }
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(text = "Manage Accounts") },
+                navigationIcon = {
+                    BackButton(onClick = { navController.popBackStack() })
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = modifier
+                .padding(paddingValues)
+                .displayCutoutPadding()
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            AccountsGroup(navController = navController)
+        }
+    }
+}
+
+@Composable
+private fun AccountsGroup(
+    navController: NavController
+) {
+    SettingsGroup(title = { Text(text = "Accounts") }) {
+        SteamAccountSection(navController = navController)
+        // Other account sections (GOG, Epic Games, etc.)
+    }
+}
+
+@Composable
+private fun AccountInfoCard() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Platform Information",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            
+            Text(
+                text = "• You can use GameNative without logging into any accounts\n" +
+                      "• Steam login enables downloading and playing Steam games",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+// Keep the existing AccountSection for backward compatibility
+@Composable
+fun AccountSection(
+    title: String,
+    description: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    isLoggedIn: Boolean,
+    username: String?,
+    onLogin: () -> Unit,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    error: String? = null
+) {
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val tertiaryColor = MaterialTheme.colorScheme.tertiary
+    
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.95f)
+        ),
+        border = BorderStroke(1.dp, primaryColor.copy(alpha = 0.2f)),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(primaryColor, tertiaryColor, primaryColor)
+                    )
+                )
+        )
+        
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(32.dp),
+                    tint = if (isLoggedIn) 
+                        MaterialTheme.colorScheme.onPrimaryContainer 
+                    else 
+                        MaterialTheme.colorScheme.onSurface
+                )
+                
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (isLoggedIn) 
+                            MaterialTheme.colorScheme.onPrimaryContainer 
+                        else 
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                    
+                    Text(
+                        text = if (isLoggedIn && username != null) 
+                            "Logged in as $username" 
+                        else 
+                            description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isLoggedIn) 
+                            MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                        else 
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                
+                // Status indicator
+                Icon(
+                    imageVector = if (isLoggedIn) Icons.Default.CheckCircle else Icons.Default.Circle,
+                    contentDescription = if (isLoggedIn) "Connected" else "Not connected",
+                    tint = if (isLoggedIn) 
+                        MaterialTheme.colorScheme.primary 
+                    else 
+                        MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            
+            // Error message
+            if (error != null) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Text(
+                        text = error,
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
+            
+            // Action button
+            if (isLoggedIn) {
+                OutlinedButton(
+                    onClick = onLogout,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isLoading
+                ) {
+                    if (isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Icon(Icons.Default.Logout, contentDescription = null)
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Sign Out")
+                }
+            } else {
+                Button(
+                    onClick = onLogin,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isLoading
+                ) {
+                    if (isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    } else {
+                        Icon(Icons.Default.Login, contentDescription = null)
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(if (isLoading) "Signing In..." else "Sign In")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun SteamAccountSection(
     navController: NavController,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
     val isSteamLoggedIn = SteamService.isLoggedIn
@@ -36,6 +36,6 @@ fun SteamAccountSection(
                 }
             }
         },
-        modifier = modifier
+        modifier = modifier,
     )
 }

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -1,0 +1,39 @@
+package app.gamenative.ui.screen.accounts
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Games
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import app.gamenative.service.SteamService
+import app.gamenative.ui.screen.PluviaScreen
+import kotlinx.coroutines.launch
+
+@Composable
+fun SteamAccountSection(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    
+    // State for Steam
+    val isSteamLoggedIn = SteamService.isLoggedIn
+    
+    AccountSection(
+        title = "Steam",
+        description = "Access your Steam library and games",
+        icon = Icons.Default.Games,
+        isLoggedIn = isSteamLoggedIn,
+        username = if (isSteamLoggedIn) "Steam User" else null,
+        onLogin = {
+            navController.navigate(PluviaScreen.LoginUser.route)
+        },
+        onLogout = {
+            scope.launch {
+                SteamService.logOut()
+            }
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -11,22 +11,18 @@ fun SteamAccountSection(
     onNavigateRoute: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scope = rememberCoroutineScope()
-    val isSteamLoggedIn = SteamService.isLoggedIn
+    val isSteamLoggedIn = remember { mutableStateOf(SteamService.isLoggedIn)}
 
     AccountSection(
         title = "Steam",
         description = "Access your Steam library and games",
         icon = "https://store.steampowered.com/favicon.ico",
-        isLoggedIn = isSteamLoggedIn,
-        username = if (isSteamLoggedIn) "Steam User" else null,
+        isLoggedIn = isSteamLoggedIn.value,
+        username = if (isSteamLoggedIn.value) "Steam User" else null,
         onLogin = { onNavigateRoute(PluviaScreen.LoginUser.route) },
         onLogout = {
-            scope.launch {
-                SteamService.logOut()
-                // Re-navigate to current screen to refresh logged in state
-                onNavigateRoute(PluviaScreen.AccountManagement.route)
-            }
+            SteamService.logOut()
+            isSteamLoggedIn.value = false // Trigger a redraw
         },
         modifier = modifier,
     )

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -16,10 +16,8 @@ fun SteamAccountSection(
     modifier: Modifier = Modifier
 ) {
     val scope = rememberCoroutineScope()
-    
-    // State for Steam
     val isSteamLoggedIn = SteamService.isLoggedIn
-    
+
     AccountSection(
         title = "Steam",
         description = "Access your Steam library and games",
@@ -32,6 +30,13 @@ fun SteamAccountSection(
         onLogout = {
             scope.launch {
                 SteamService.logOut()
+                // Re-navigate to current screen to refresh logged in state
+                navController.navigate(PluviaScreen.AccountManagement.route) {
+                    popUpTo(PluviaScreen.Home.route) {
+                        inclusive = false
+                    }
+                    launchSingleTop = true
+                }
             }
         },
         modifier = modifier

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -2,14 +2,13 @@ package app.gamenative.ui.screen.accounts
 
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavController
 import app.gamenative.service.SteamService
 import app.gamenative.ui.screen.PluviaScreen
 import kotlinx.coroutines.launch
 
 @Composable
 fun SteamAccountSection(
-    navController: NavController,
+    onNavigateRoute: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
@@ -21,19 +20,12 @@ fun SteamAccountSection(
         icon = "https://store.steampowered.com/favicon.ico",
         isLoggedIn = isSteamLoggedIn,
         username = if (isSteamLoggedIn) "Steam User" else null,
-        onLogin = {
-            navController.navigate(PluviaScreen.LoginUser.route)
-        },
+        onLogin = { onNavigateRoute(PluviaScreen.LoginUser.route) },
         onLogout = {
             scope.launch {
                 SteamService.logOut()
                 // Re-navigate to current screen to refresh logged in state
-                navController.navigate(PluviaScreen.AccountManagement.route) {
-                    popUpTo(PluviaScreen.Home.route) {
-                        inclusive = false
-                    }
-                    launchSingleTop = true
-                }
+                onNavigateRoute(PluviaScreen.AccountManagement.route)
             }
         },
         modifier = modifier,

--- a/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/accounts/SteamAccountSection.kt
@@ -1,8 +1,5 @@
 package app.gamenative.ui.screen.accounts
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Games
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -21,7 +18,7 @@ fun SteamAccountSection(
     AccountSection(
         title = "Steam",
         description = "Access your Steam library and games",
-        icon = Icons.Default.Games,
+        icon = "https://store.steampowered.com/favicon.ico",
         isLoggedIn = isSteamLoggedIn,
         username = if (isSteamLoggedIn) "Steam User" else null,
         onLogin = {

--- a/app/src/main/java/app/gamenative/ui/screen/downloads/HomeDownloadsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/downloads/HomeDownloadsScreen.kt
@@ -40,14 +40,12 @@ import app.gamenative.ui.theme.PluviaTheme
 @Composable
 fun HomeDownloadsScreen(
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     DownloadsScreenContent(
         onBack = { onBackPressedDispatcher?.onBackPressed() },
         onNavigateRoute = onNavigateRoute,
-        onLogout = onLogout,
     )
 }
 
@@ -56,7 +54,6 @@ fun HomeDownloadsScreen(
 private fun DownloadsScreenContent(
     onBack: () -> Unit,
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     val snackbarHost = remember { SnackbarHostState() }
     val navigator = rememberListDetailPaneScaffoldNavigator<Long>()
@@ -79,7 +76,6 @@ private fun DownloadsScreenContent(
                     },
                     onBack = onBack,
                     onNavigateRoute = onNavigateRoute,
-                    onLogout = onLogout,
                 )
             }
         },
@@ -103,7 +99,6 @@ private fun DownloadsScreenPane(
     onClick: () -> Unit,
     onBack: () -> Unit,
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHost) },
@@ -113,7 +108,6 @@ private fun DownloadsScreenPane(
                 actions = {
                     AccountButton(
                         onNavigateRoute = onNavigateRoute,
-                        onLogout = onLogout,
                     )
                 },
                 navigationIcon = { BackButton(onClick = onBack) },
@@ -198,7 +192,6 @@ private fun Preview_DownloadsScreenContent() {
             DownloadsScreenContent(
                 onBack = {},
                 onNavigateRoute = {},
-                onLogout = {},
             )
         }
     }

--- a/app/src/main/java/app/gamenative/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/friends/FriendsScreen.kt
@@ -247,7 +247,6 @@ private fun FriendsListPane(
                 actions = {
                     AccountButton(
                         onNavigateRoute = onNavigateRoute,
-                        onLogout = onLogout,
                     )
                 },
                 navigationIcon = { BackButton(onClick = onBack) },

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -5,29 +5,21 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.displayCutoutPadding
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.layout.AnimatedPane
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
-import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
-import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -36,15 +28,11 @@ import app.gamenative.data.LibraryItem
 import app.gamenative.service.SteamService
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
-import app.gamenative.ui.enums.Orientation
-import app.gamenative.events.AndroidEvent
-import app.gamenative.PluviaApp
 import app.gamenative.ui.internal.fakeAppInfo
 import app.gamenative.ui.model.LibraryViewModel
 import app.gamenative.ui.screen.library.components.LibraryDetailPane
 import app.gamenative.ui.screen.library.components.LibraryListPane
 import app.gamenative.ui.theme.PluviaTheme
-import java.util.EnumSet
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,14 +76,16 @@ private fun LibraryScreenContent(
 
     BackHandler(selectedAppId != null) { selectedAppId = null }
     val safePaddingModifier =
-        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT)
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
             Modifier.displayCutoutPadding()
-        else
+        } else {
             Modifier
+        }
 
     Box(
         Modifier.background(MaterialTheme.colorScheme.background)
-        .then(safePaddingModifier)) {
+            .then(safePaddingModifier),
+    ) {
         if (selectedAppId == null) {
             LibraryListPane(
                 state = state,
@@ -107,7 +97,7 @@ private fun LibraryScreenContent(
                 onIsSearching = onIsSearching,
                 onSearchQuery = onSearchQuery,
                 onNavigateRoute = onNavigateRoute,
-                onNavigate = { appId -> selectedAppId = appId }
+                onNavigate = { appId -> selectedAppId = appId },
             )
         } else {
             LibraryDetailPane(

--- a/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/LibraryScreen.kt
@@ -52,7 +52,6 @@ fun HomeLibraryScreen(
     viewModel: LibraryViewModel = hiltViewModel(),
     onClickPlay: (Int, Boolean) -> Unit,
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -68,7 +67,6 @@ fun HomeLibraryScreen(
         onSearchQuery = viewModel::onSearchQuery,
         onClickPlay = onClickPlay,
         onNavigateRoute = onNavigateRoute,
-        onLogout = onLogout,
     )
 }
 
@@ -85,7 +83,6 @@ private fun LibraryScreenContent(
     onSearchQuery: (String) -> Unit,
     onClickPlay: (Int, Boolean) -> Unit,
     onNavigateRoute: (String) -> Unit,
-    onLogout: () -> Unit,
 ) {
     var selectedAppId by remember { mutableStateOf<Int?>(null) }
 
@@ -110,7 +107,6 @@ private fun LibraryScreenContent(
                 onIsSearching = onIsSearching,
                 onSearchQuery = onSearchQuery,
                 onNavigateRoute = onNavigateRoute,
-                onLogout = onLogout,
                 onNavigate = { appId -> selectedAppId = appId }
             )
         } else {
@@ -173,7 +169,6 @@ private fun Preview_LibraryScreenContent() {
             },
             onClickPlay = { _, _ -> },
             onNavigateRoute = {},
-            onLogout = {},
         )
     }
 }

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -32,7 +32,7 @@ internal fun LibraryDetailPane(
                 LibraryState(
                     appInfoList = emptyList(),
                     // Use the same default filter as in PrefManager (GAME)
-                    appInfoSortType = EnumSet.of(AppFilter.GAME)
+                    appInfoSortType = EnumSet.of(AppFilter.GAME),
                 )
             }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryDetailPane.kt
@@ -44,10 +44,9 @@ internal fun LibraryDetailPane(
                 onPageChange = {},
                 onModalBottomSheet = {},
                 onIsSearching = {},
-                onLogout = {},
-                onNavigate = {},
                 onSearchQuery = {},
                 onNavigateRoute = {},
+                onNavigate = {},
             )
         } else {
             AppScreen(

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -9,12 +9,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -24,13 +28,16 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,24 +46,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import app.gamenative.PrefManager
 import app.gamenative.data.LibraryItem
+import app.gamenative.service.DownloadService
+import app.gamenative.ui.component.topbar.AccountButton
 import app.gamenative.ui.data.LibraryState
 import app.gamenative.ui.enums.AppFilter
 import app.gamenative.ui.internal.fakeAppInfo
-import app.gamenative.service.DownloadService
 import app.gamenative.ui.theme.PluviaTheme
-import app.gamenative.ui.component.topbar.AccountButton
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
-import app.gamenative.PrefManager
 import app.gamenative.utils.DeviceUtils
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -85,31 +85,32 @@ internal fun LibraryListPane(
             .filterNotNull()
             .distinctUntilChanged()
             .collect { lastVisibleIndex ->
-                if (lastVisibleIndex >= state.appInfoList.lastIndex
-                    && state.appInfoList.size < state.totalAppsInFilter) {
+                if (lastVisibleIndex >= state.appInfoList.lastIndex &&
+                    state.appInfoList.size < state.totalAppsInFilter
+                ) {
                     onPageChange(1)
                 }
             }
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackBarHost) }
+        snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = paddingValues.calculateTopPadding())
+                .padding(top = paddingValues.calculateTopPadding()),
         ) {
             // Modern Header with gradient
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp)
+                    .padding(16.dp),
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween
+                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween,
                 ) {
                     Column {
                         Text(
@@ -119,15 +120,15 @@ internal fun LibraryListPane(
                                 brush = Brush.horizontalGradient(
                                     colors = listOf(
                                         MaterialTheme.colorScheme.primary,
-                                        MaterialTheme.colorScheme.tertiary
-                                    )
-                                )
-                            )
+                                        MaterialTheme.colorScheme.tertiary,
+                                    ),
+                                ),
+                            ),
                         )
                         Text(
                             text = "${state.totalAppsInFilter} games • $installedCount installed",
                             style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
 
@@ -135,7 +136,7 @@ internal fun LibraryListPane(
                         Box(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(horizontal = 30.dp)
+                                .padding(horizontal = 30.dp),
                         ) {
                             LibrarySearchBar(
                                 state = state,
@@ -150,7 +151,7 @@ internal fun LibraryListPane(
                         modifier = Modifier
                             .clip(RoundedCornerShape(12.dp))
                             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-                            .padding(8.dp)
+                            .padding(8.dp),
                     ) {
                         AccountButton(
                             onNavigateRoute = onNavigateRoute,
@@ -159,12 +160,12 @@ internal fun LibraryListPane(
                 }
             }
 
-            if (! isViewWide) {
+            if (!isViewWide) {
                 // Search bar
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 12.dp)
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
                 ) {
                     LibrarySearchBar(
                         state = state,
@@ -184,14 +185,14 @@ internal fun LibraryListPane(
                     contentPadding = PaddingValues(
                         start = 20.dp,
                         end = 20.dp,
-                        bottom = 72.dp
+                        bottom = 72.dp,
                     ),
                 ) {
                     items(items = state.appInfoList, key = { it.index }) { item ->
                         AppItem(
                             modifier = Modifier.animateItem(),
                             appInfo = item,
-                            onClick = { onNavigate(item.appId) }
+                            onClick = { onNavigate(item.appId) },
                         )
                         if (item.index < state.appInfoList.lastIndex) {
                             HorizontalDivider()
@@ -203,7 +204,7 @@ internal fun LibraryListPane(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(16.dp),
-                                contentAlignment = Alignment.Center
+                                contentAlignment = Alignment.Center,
                             ) {
                                 CircularProgressIndicator()
                             }
@@ -222,7 +223,7 @@ internal fun LibraryListPane(
                         contentColor = MaterialTheme.colorScheme.onPrimary,
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
-                            .padding(24.dp)
+                            .padding(24.dp),
                     )
                 }
 

--- a/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/app/gamenative/ui/screen/library/components/LibraryListPane.kt
@@ -68,7 +68,6 @@ internal fun LibraryListPane(
     onModalBottomSheet: (Boolean) -> Unit,
     onPageChange: (Int) -> Unit,
     onIsSearching: (Boolean) -> Unit,
-    onLogout: () -> Unit,
     onNavigate: (Int) -> Unit,
     onSearchQuery: (String) -> Unit,
     onNavigateRoute: (String) -> Unit,
@@ -155,7 +154,6 @@ internal fun LibraryListPane(
                     ) {
                         AccountButton(
                             onNavigateRoute = onNavigateRoute,
-                            onLogout = onLogout
                         )
                     }
                 }
@@ -289,7 +287,6 @@ private fun Preview_LibraryListPane() {
                 onIsSearching = { },
                 onSearchQuery = { },
                 onNavigateRoute = { },
-                onLogout = { },
                 onNavigate = { },
             )
         }


### PR DESCRIPTION
This PR will allow a location in the UX for adding authentication for multiple accounts (like GOG, Epic, etc.) 
I've moved Steam authentication to this screen as well.

This has a couple of side effects:
- Since we don't depend specifically on Steam anymore, the app will now just open in the empty library section.
- Steam authentication has been moved to the new "Manage Accounts" view.
- Sign out has been moved there as well.

Flow:
<img width="250" height="2048" alt="image" src="https://github.com/user-attachments/assets/b4bfa1db-f575-4b0a-bd70-ac19d014e0f0" />
<img width="250" height="2048" alt="image" src="https://github.com/user-attachments/assets/7ce5751f-7fcf-4f9d-a910-4ebd04b8c725" />
<img width="250" height="2048" alt="image" src="https://github.com/user-attachments/assets/0bb5ffc4-f95b-4a5e-a7d8-52dec6bd73ec" />
<img width="250" height="2048" alt="image" src="https://github.com/user-attachments/assets/ff2476a2-19fc-4874-ac38-7739ad18eb03" />
<img width="250" height="2048" alt="image" src="https://github.com/user-attachments/assets/beda3f4d-8d93-4cd8-8b6f-cdaf6fc4a11e" />

