### PR TITLE
Extracted icon to gamemanagers

### DIFF
--- a/app/src/main/java/app/gamenative/data/LibraryItem.kt
+++ b/app/src/main/java/app/gamenative/data/LibraryItem.kt
@@ -1,6 +1,7 @@
 package app.gamenative.data
 
 import app.gamenative.Constants
+import app.gamenative.service.GameManagerService
 
 /**
  * Data class for the Library list
@@ -14,7 +15,7 @@ data class LibraryItem(
     val gameSource: GameSource = GameSource.STEAM,
 ) {
     val clientIconUrl: String
-        get() = Constants.Library.ICON_URL + "$gameId/$iconHash.ico"
+        get() = GameManagerService.getIconImage(this)
 
     /**
      * Helper property to get the game ID as an integer

--- a/app/src/main/java/app/gamenative/service/GameManager.kt
+++ b/app/src/main/java/app/gamenative/service/GameManager.kt
@@ -116,6 +116,12 @@ interface GameManager {
      */
     fun getHeroImage(libraryItem: LibraryItem): String
 
+
+    /**
+     * Get the icon image for the given game
+     */
+    fun getIconImage(libraryItem: LibraryItem): String
+
     /**
      * Returns the install info dialog for the given game
      */

--- a/app/src/main/java/app/gamenative/service/GameManagerService.kt
+++ b/app/src/main/java/app/gamenative/service/GameManagerService.kt
@@ -192,6 +192,10 @@ class GameManagerService @Inject constructor(
             return getManagerForGame(libraryItem).getHeroImage(libraryItem)
         }
 
+        fun getIconImage(libraryItem: LibraryItem): String {
+            return getManagerForGame(libraryItem).getIconImage(libraryItem)
+        }
+
         fun getInstallInfoDialog(context: Context, libraryItem: LibraryItem): MessageDialogState {
             return getManagerForGame(libraryItem).getInstallInfoDialog(context, libraryItem)
         }

--- a/app/src/main/java/app/gamenative/service/Steam/SteamGameManager.kt
+++ b/app/src/main/java/app/gamenative/service/Steam/SteamGameManager.kt
@@ -3,6 +3,7 @@ package app.gamenative.service.Steam
 import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
+import app.gamenative.Constants
 import app.gamenative.R
 import app.gamenative.data.DownloadInfo
 import app.gamenative.data.Game
@@ -245,6 +246,10 @@ class SteamGameManager @Inject constructor(
     override fun getHeroImage(libraryItem: LibraryItem): String {
         val appInfo = getAppInfo(libraryItem)
         return appInfo?.getHeroUrl() ?: ""
+    }
+
+    override fun getIconImage(libraryItem: LibraryItem): String {
+        return Constants.Library.ICON_URL + "${libraryItem.gameId}/${libraryItem.iconHash}.ico"
     }
 
     override fun getInstallInfoDialog(context: Context, libraryItem: LibraryItem): MessageDialogState {

--- a/app/src/main/java/app/gamenative/ui/internal/FakeGameManager.kt
+++ b/app/src/main/java/app/gamenative/ui/internal/FakeGameManager.kt
@@ -95,6 +95,7 @@ object FakeGameManager : GameManager {
     override fun getReleaseDate(libraryItem: LibraryItem): String = "2024-01-01"
 
     override fun getHeroImage(libraryItem: LibraryItem): String = ""
+    override fun getIconImage(libraryItem: LibraryItem): String = ""
 
     override fun getInstallInfoDialog(context: Context, libraryItem: LibraryItem): MessageDialogState {
         return MessageDialogState(


### PR DESCRIPTION
This PR will make sure icon urls are properly extracted to the game managers so that steam can call a url independent from other platforms.